### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:latest
+
+RUN apt-get update
+# Avoid problem with tzdata install...
+# Sets timezone to UTC though
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+
+# Install dependencies
+RUN apt-get install -y build-essential gdb lcov pkg-config \
+    libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
+    libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
+    lzma lzma-dev tk-dev uuid-dev zlib1g-dev curl python3 python3-pip
+
+RUN apt-get install -y libusb-dev make git avr-libc gcc-avr \
+    gcc-arm-none-eabi libusb-1.0-0-dev usbutils
+
+# Download chipwhisperer
+RUN mkdir -p /opt/chipwhisperer
+WORKDIR /opt/chipwhisperer
+RUN git clone --recursive --depth=1 --branch 5.7.0 https://github.com/newaetech/chipwhisperer.git
+
+# Install chipwhisperer
+WORKDIR /opt/chipwhisperer/chipwhisperer/
+RUN python3 -m pip install -e .
+RUN python3 -m pip install -r jupyter/requirements.txt
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "Chipwhisperer",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "remoteEnv": {
+        "CWFIRMWAREPATH": "/opt/chipwhisperer/chipwhisperer/hardware/victims/firmware"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-toolsai.jupyter"
+            ]
+        }
+    },
+    "postCreateCommand": "pip3 install -r requirements.txt",
+    "postAttachCommand": "",
+    "runArgs": [
+        "--privileged"
+    ],
+    "mounts": ["type=bind,source=/dev/bus/usb,target=/dev/bus/usb"]
+}


### PR DESCRIPTION
# Add a ubuntu based [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers)

to use this you need the [Microsoft Remote Container ](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for vscode

* container includes all dependencies for chipwhisperer and jupyter
* vscode will:
  * install the python requirements of this repo
  * add the `CWFIRMWAREPATH` environment variable
  * install python and jupyter extensions
  * mount `/dev/bus/usb` in the container to make the chipwhisperer available (**may only work on a linux host**) 